### PR TITLE
Set count

### DIFF
--- a/lib/progressrus.rb
+++ b/lib/progressrus.rb
@@ -54,6 +54,10 @@ class Progressrus
     persist
   end
 
+  def count=(new_count, **args)
+    tick(new_count - @count, *args)
+  end
+
   def complete(now: Time.now)
     @started_at ||= now
     @completed_at = now

--- a/test/progressrus_test.rb
+++ b/test/progressrus_test.rb
@@ -249,4 +249,22 @@ class ProgressrusTest < Minitest::Unit::TestCase
     assert_instance_of Time, @progress.started_at
     assert_instance_of Time, @progress.completed_at
   end
+
+  def test_able_to_set_count
+    @progress.count = 100
+    assert_equal 100, @progress.count
+  end
+
+  def test_call_persist_after_setting_count
+    @progress.expects(:persist).once
+
+    @progress.count = 100
+  end
+
+  def test_set_started_at_if_not_set
+    @progress.instance_variable_set(:@started_at, nil)
+    @progress.count = 100
+
+    assert_instance_of Time, @progress.started_at
+  end
 end


### PR DESCRIPTION
This is to set the count directly on a progressrus instance. This allows us to skip MySQL counts, by setting total to `max(id)` (which is indexed) and then setting the count to the current id.

I'll bump this in Shopify as well, and then post my Vault page.

@kristianpd @camilo
