### PR TITLE
Loosen redis-rb dep

### DIFF
--- a/progressrus.gemspec
+++ b/progressrus.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "redis", "~> 3.0.4"
+  spec.add_dependency "redis", "~> 3.0"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "mocha", "~> 0.14"


### PR DESCRIPTION
I notice you were specific about this dep in https://github.com/Sirupsen/progressrus/commit/0fabf7106165ba29cff52e2b3a76ea07767b9aef, but I want to loosen it to allow 3.1.0 so I can bump Shopify up to that version.

The tests passed for me on redis-rb 3.0.4, 3.0.6, and 3.1.0.

@Sirupsen
