### PR TITLE
decouple error and tick

### DIFF
--- a/lib/progressrus.rb
+++ b/lib/progressrus.rb
@@ -66,7 +66,6 @@ class Progressrus
   def error(ticks = 1, now: Time.now)
     @error_count ||= 0
     @error_count += ticks
-    tick(ticks, now: now)
   end
 
   def count=(new_count, **args)

--- a/test/progressrus_test.rb
+++ b/test/progressrus_test.rb
@@ -59,21 +59,19 @@ class ProgressrusTest < Minitest::Unit::TestCase
     assert_equal 50, @progress.count
   end
 
-  def test_error_should_call_tick
-    @progress.expects(:tick).once
+  def test_error_should_not_call_tick
+    @progress.expects(:tick).never
     @progress.error
   end
 
-  def test_error_should_increment_error_count_and_count_by_one_if_not_specified
+  def test_error_should_increment_error_count_by_one_if_amount_not_specified
     @progress.error
     assert_equal 1, @progress.error_count
-    assert_equal 1, @progress.count
   end
 
-  def test_error_should_increment_error_count_and_count
+  def test_error_should_increment_error_count
     @progress.error(25)
     assert_equal 25, @progress.error_count
-    assert_equal 25, @progress.count
   end
 
   def test_eta_should_return_nil_if_no_count


### PR DESCRIPTION
@Sirupsen -- @DrewMartin originally wanted `#error` to implicitly call `#tick` so when an error occurred we wouldn't forget to increment the tick count and cause estimated completion times to be skewed.

However, we're now working on a maintenance task base class that will `ensure progress.tick`, so I want to decouple these. Another reason to do this is when you fail a batch, you may want to increase the count by e.g. 1000, but the error count by 1... or a scenario where you want to log several errors for the same record.

Anyway, there are reasons we'd want to increase these two values by different amounts; you cool with that?
