### PR TITLE
Option to persist on initialize

### DIFF
--- a/lib/progressrus.rb
+++ b/lib/progressrus.rb
@@ -39,7 +39,7 @@ class Progressrus
   def initialize(scope: "progressrus", total: nil, name: nil,
     id: SecureRandom.uuid, params: {}, stores: Progressrus.stores,
     completed_at: nil, started_at: nil, count: 0, failed_at: nil,
-    error_count: 0)
+    error_count: 0, persist: false)
 
     raise ArgumentError, "Total cannot be zero or negative." if total && total <= 0
 
@@ -55,6 +55,8 @@ class Progressrus
     @started_at   = parse_time(started_at)
     @completed_at = parse_time(completed_at)
     @failed_at    = parse_time(failed_at)
+
+    persist(force: true) if persist
   end
 
   def tick(ticks = 1, now: Time.now)

--- a/test/progressrus_test.rb
+++ b/test/progressrus_test.rb
@@ -38,6 +38,11 @@ class ProgressrusTest < Minitest::Unit::TestCase
     assert_equal 'oemg', progressrus.name
   end
 
+  def test_initialize_with_persist
+    Progressrus.any_instance.expects(:persist).with(force: true).once
+    progressrus = Progressrus.new(persist: true)
+  end
+
   def test_tick_should_set_started_at_if_not_already_set_and_tick_greater_than_zero
     @progress.tick
     assert @progress.started_at


### PR DESCRIPTION
@Sirupsen 

This exposes an option to persist the progressrus when it is initialized. When enqueuing the job I want to store the progressrus but in started state. 
