### PR TITLE
Rescue Redis::BaseError in Progressrus::Store::Redis

### DIFF
--- a/lib/progressrus.rb
+++ b/lib/progressrus.rb
@@ -149,8 +149,14 @@ class Progressrus
   end
 
   private
+
   def persist(force: false)
-    stores.each { |store| store.persist(self, force: force) }
+    stores.each do |store|
+      begin
+        store.persist(self, force: force)
+      rescue Progressrus::Store::BackendError => e
+      end
+    end
   end
 
   def parse_time(time)

--- a/lib/progressrus/store/base.rb
+++ b/lib/progressrus/store/base.rb
@@ -1,6 +1,7 @@
 class Progressrus
   class Store
     class NotImplementedError < StandardError; end
+    class BackendError < StandardError; end
 
     class Base
       def persist(progress)

--- a/test/progressrus_test.rb
+++ b/test/progressrus_test.rb
@@ -192,6 +192,13 @@ class ProgressrusTest < Minitest::Unit::TestCase
     @progress.tick
   end
 
+  def test_tick_and_complete_dont_raise_if_store_is_unavailable
+    store = Progressrus.stores.first
+    store.redis.expects(:hset).at_least_once.raises(::Redis::BaseError)
+    @progress.tick
+    @progress.complete
+  end
+
   def test_should_not_be_able_to_initialize_with_total_0
     assert_raises ArgumentError do
       Progressrus.new(total: 0)


### PR DESCRIPTION
Make sure the Progressrus instrumentation of a job can't break the job itself but rather just accept the data loss and keep going.

@Sirupsen, thoughts? Useful? Necessary? Want real Toxiproxy tests?