### PR TITLE
Allow the total to be zero.

### DIFF
--- a/lib/progressrus.rb
+++ b/lib/progressrus.rb
@@ -42,7 +42,7 @@ class Progressrus
     completed_at: nil, started_at: nil, count: 0, failed_at: nil,
     error_count: 0, persist: false, expires_at: nil)
 
-    raise ArgumentError, "Total cannot be zero or negative." if total && total <= 0
+    raise ArgumentError, "Total cannot be negative." if total && total < 0
 
     @name         = name || id
     @scope        = Array(scope).map(&:to_s)
@@ -120,7 +120,7 @@ class Progressrus
   end
 
   def total=(new_total)
-    raise ArgumentError, "Total cannot be zero or negative." if new_total <= 0
+    raise ArgumentError, "Total cannot be negative." if new_total < 0
     @total = new_total
   end
 
@@ -133,7 +133,11 @@ class Progressrus
   end
 
   def percentage
-    count.to_f / total
+    if total > 0
+      count.to_f / total
+    else
+      1.0
+    end
   end
 
   def eta(now: Time.now)

--- a/test/progressrus_test.rb
+++ b/test/progressrus_test.rb
@@ -110,8 +110,15 @@ class ProgressrusTest < Minitest::Test
     assert_equal 1.2, @progress.percentage
   end
 
-  def test_percentage_should_be_0_if_total_0
+  def test_percentage_should_be_0_if_count_0
     assert_equal 0, @progress.percentage
+  end
+
+  def test_percentage_should_be_1_if_total_0
+    progress = Progressrus.new(total: 0)
+    assert_equal 1, progress.percentage
+    progress.tick
+    assert_equal 1, progress.percentage
   end
 
   def test_elapsed_should_return_the_delta_between_now_and_started_at
@@ -168,10 +175,9 @@ class ProgressrusTest < Minitest::Test
     assert_equal now.to_i, @progress.completed_at.to_i
   end
 
-  def test_should_not_be_able_to_set_total_to_0
-    assert_raises ArgumentError do
-      @progress.total = 0
-    end
+  def test_should_be_able_to_set_total_to_0
+    @progress.total = 0
+    assert_equal 0, @progress.total
   end
 
   def test_should_not_be_able_to_set_total_to_a_negative_number
@@ -199,10 +205,9 @@ class ProgressrusTest < Minitest::Test
     @progress.complete
   end
 
-  def test_should_not_be_able_to_initialize_with_total_0
-    assert_raises ArgumentError do
-      Progressrus.new(total: 0)
-    end
+  def test_should_be_able_to_initialize_with_total_0
+    progress = Progressrus.new(total: 0)
+    assert_equal 0, progress.total
   end
 
   def test_should_not_be_able_to_initialize_with_total_as_a_negative_number


### PR DESCRIPTION
For review @sirupsen @fw42 @eapache @disaacs

@fw42 suggested allowing Progressrus to accept a total of zero as a better alternative than my original proposal to avoid passing zero into Progressrus.

I've made that change here, modifying `percentage` to return `1.0` if the total is zero.