### PR TITLE
Fix updating total after persistence

### DIFF
--- a/lib/progressrus.rb
+++ b/lib/progressrus.rb
@@ -40,7 +40,7 @@ class Progressrus
   def initialize(scope: "progressrus", total: nil, name: nil,
     id: SecureRandom.uuid, params: {}, stores: Progressrus.stores,
     completed_at: nil, started_at: nil, count: 0, failed_at: nil,
-    error_count: 0, persist: false, expires_at: nil)
+    error_count: 0, persist: false, expires_at: nil, persisted: false)
 
     raise ArgumentError, "Total cannot be negative." if total && total < 0
 
@@ -57,6 +57,7 @@ class Progressrus
     @completed_at = parse_time(completed_at)
     @failed_at    = parse_time(failed_at)
     @expires_at   = parse_time(expires_at)
+    @persisted    = persisted
 
     persist(force: true) if persist
   end
@@ -122,6 +123,8 @@ class Progressrus
   def total=(new_total)
     raise ArgumentError, "Total cannot be negative." if new_total < 0
     @total = new_total
+    persist(force: true) if persisted?
+    @total
   end
 
   def total
@@ -153,6 +156,10 @@ class Progressrus
     expires_at && expires_at < now
   end
 
+  def persisted?
+    @persisted
+  end
+
   private
 
   def persist(force: false)
@@ -162,6 +169,7 @@ class Progressrus
       rescue Progressrus::Store::BackendError => e
       end
     end
+    @persisted = true
   end
 
   def parse_time(time)

--- a/lib/progressrus/store/redis.rb
+++ b/lib/progressrus/store/redis.rb
@@ -63,7 +63,7 @@ class Progressrus
       end
 
       def deserialize(value)
-        JSON.parse(value, symbolize_names: true)
+        JSON.parse(value, symbolize_names: true).merge(persisted: true)
       end
 
       def outdated?(progress, now: Time.now)

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -21,6 +21,14 @@ class IntegrationTest < Minitest::Test
     assert_equal 1, tick.count
   end
 
+  def test_setting_total_after_persist_persists_total
+    progress = Progressrus.new(scope: ["walrus"], total: 0, persist: true, id: '123')
+    assert_equal 0, progress.total
+    progress.total = 20
+    progress = Progressrus.find(["walrus"], '123')
+    assert_equal 20, progress.total
+  end
+
   def test_create_multiple_ticks_and_see_them_in_redis
     @progress.tick
 

--- a/test/store/redis_test.rb
+++ b/test/store/redis_test.rb
@@ -38,12 +38,14 @@ class RedisStoreTest < Minitest::Test
   end
 
   def test_scope_should_return_progressruses_indexed_by_id
-  	@store.persist(@progress)
-  	@store.persist(@another_progress)
-  	actual = @store.scope(@scope)
+    @store.persist(@progress)
+    @store.persist(@another_progress)
+    actual = @store.scope(@scope)
 
-  	assert_equal @progress.id, actual['oemg'].id
-  	assert_equal @another_progress.id, actual['oemg-two'].id
+    assert_equal @progress.id, actual['oemg'].id
+    assert actual['oemg'].persisted?
+    assert_equal @another_progress.id, actual['oemg-two'].id
+    assert actual['oemg-two'].persisted?
   end
 
   def test_scope_should_return_an_empty_hash_if_nothing_is_found
@@ -51,9 +53,10 @@ class RedisStoreTest < Minitest::Test
   end
 
   def test_find_should_return_a_single_progressrus_for_scope_and_id
-  	@store.persist(@progress)
-
-  	assert_equal @progress.id, @store.find(@scope, 'oemg').id
+    @store.persist(@progress)
+    stored_progress = @store.find(@scope, 'oemg')
+    assert_equal @progress.id, stored_progress.id
+    assert stored_progress.persisted?
   end
 
   def test_find_should_return_nil_if_nothing_is_found


### PR DESCRIPTION
@sirupsen 

If `persist: true` is called in the constructor, the total can never get updated. I know it's an edge case, but for completeness I figured it would be better to make it work.