### PR TITLE
Convert expires_at to integer before settings redis ttl

### DIFF
--- a/lib/progressrus/store/redis.rb
+++ b/lib/progressrus/store/redis.rb
@@ -19,7 +19,7 @@ class Progressrus
 
           redis.pipelined do
             redis.hset(key_for_scope, progress.id, progress.to_serializeable.to_json)
-            redis.expireat(key_for_scope, expires_at) if expires_at
+            redis.expireat(key_for_scope, expires_at.to_i) if expires_at
           end
 
           @persisted_ats[progress.scope][progress.id] = now


### PR DESCRIPTION
```
(byebug) redis.hset(key_for_scope, progress.id, progress.to_serializeable.to_json)
true
(byebug) redis.expireat(key_for_scope, expires_at)
*** Redis::CommandError Exception: ERR value is not an integer or out of range

nil
(byebug) 
```

The `expires_at` field gets set as a `Time` object into the progressrus api but redis expects this to be a timestamp. This raises an exception but gets caught by:

https://github.com/sirupsen/progressrus/blob/e468f12a652421cbaa6a6ba3119c09a0e7443e41/lib/progressrus/store/redis.rb#L27-L29

As `Redis::CommandError` extends from `Redis::BaseError`

And this is then swallowed by:

https://github.com/sirupsen/progressrus/blob/e468f12a652421cbaa6a6ba3119c09a0e7443e41/lib/progressrus.rb#L169-L170

meaning only the `hset` is performed, the `expireat` never gets executed successfully.


**Todo**

- [ ] Add test cases