### PR TITLE
Stop coercing total to 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/tmp
 test/version_tmp
 tmp
 vendor/
+.ruby-version

--- a/lib/progressrus.rb
+++ b/lib/progressrus.rb
@@ -127,10 +127,6 @@ class Progressrus
     @total
   end
 
-  def total
-    @total ||= 1
-  end
-
   def elapsed(now: Time.now)
     now - started_at
   end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -70,4 +70,12 @@ class IntegrationTest < Minitest::Test
     assert_equal 0, ticks.first.count
     assert_instance_of Time, ticks.first.failed_at
   end
+
+  def test_unknown_count
+    progress = Progressrus.new(id: "omg", scope: ["walrus"], total: nil)
+    progress.tick
+
+    progress = Progressrus.find(["walrus"], "omg")
+    assert_nil progress.total
+  end
 end

--- a/test/progressrus_test.rb
+++ b/test/progressrus_test.rb
@@ -40,7 +40,7 @@ class ProgressrusTest < Minitest::Test
 
   def test_initialize_with_persist
     Progressrus.any_instance.expects(:persist).with(force: true).once
-    progressrus = Progressrus.new(persist: true)
+    Progressrus.new(persist: true)
   end
 
   def test_tick_should_set_started_at_if_not_already_set_and_tick_greater_than_zero
@@ -81,7 +81,7 @@ class ProgressrusTest < Minitest::Test
 
   def test_eta_should_return_nil_if_no_count
     progress = Progressrus.new
-    assert_equal nil, progress.eta
+    assert_nil progress.eta
   end
 
   def test_eta_should_return_time_in_future_based_on_time_elapsed
@@ -132,12 +132,9 @@ class ProgressrusTest < Minitest::Test
 
   def test_to_serializeable_set_total_to_1_if_no_total
     @progress.instance_variable_set(:@total, nil)
-    assert_equal 1, @progress.to_serializeable[:total]
-  end
 
-  def test_total_when_total_is_nil_is_1
-    @progress.instance_variable_set(:@total, nil)
-    assert_equal 1, @progress.total
+    assert @progress.to_serializeable.key?(:total)
+    assert_nil @progress.to_serializeable[:total]
   end
 
   def test_to_serializeable_should_return_a_hash_of_options

--- a/test/store/redis_test.rb
+++ b/test/store/redis_test.rb
@@ -60,7 +60,7 @@ class RedisStoreTest < Minitest::Test
   end
 
   def test_find_should_return_nil_if_nothing_is_found
-  	assert_equal nil, @store.find(@scope, 'oemg')
+  	assert_nil @store.find(@scope, 'oemg')
   end
 
   def test_flush_should_delete_by_scope
@@ -78,7 +78,7 @@ class RedisStoreTest < Minitest::Test
 
 	  @store.flush(@scope, 'oemg')
 
-  	assert_equal nil, @store.find(@scope, 'oemg')
+  	assert_nil @store.find(@scope, 'oemg')
   	assert @store.find(@scope, 'oemg-two')
   end
 


### PR DESCRIPTION
In a situation when the total number of ticks is unknown, it's common to map "unknown" state to NULL.

The current behaviour of Progressrus is:

```
    progress = Progressrus.new(id: "omg", scope: ["walrus"], total: nil)
    progress.tick # persist

    progress = Progressrus.find(["walrus"], "omg")
    progress.total
    => 1
```

IMO, it's not expected that unknown total is coerced to `1`. I'd rather keep it as `nil`. `nil` zero must be different states - one is unknown and another is known to be zero.

This PR makes Progressrus NOT coerce unknown total to `1`.

cc @Shopify/appscale @sirupsen 