### PR TITLE
Relax redis version

### DIFF
--- a/lib/progressrus.rb
+++ b/lib/progressrus.rb
@@ -164,7 +164,8 @@ class Progressrus
     stores.each do |store|
       begin
         store.persist(self, force: force, expires_at: expires_at)
-      rescue Progressrus::Store::BackendError => e
+      rescue Progressrus::Store::BackendError
+        # noop
       end
     end
     @persisted = true

--- a/lib/progressrus/store/redis.rb
+++ b/lib/progressrus/store/redis.rb
@@ -3,7 +3,7 @@ class Progressrus
     class Redis < Base
       BACKEND_EXCEPTIONS = [ ::Redis::BaseError ]
 
-      attr_reader :redis, :interval, :persisted_at, :prefix, :name
+      attr_reader :redis, :interval, :prefix, :name
 
       def initialize(instance, prefix: "progressrus", interval: 1, now: Time.now)
         @name          = :redis

--- a/progressrus.gemspec
+++ b/progressrus.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "redis", ">= 3.0"
   spec.add_dependency "ruby-progressbar", "~> 1.0"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "mocha", "~> 0.14"
   spec.add_development_dependency "pry"

--- a/progressrus.gemspec
+++ b/progressrus.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "redis", "~> 3.0"
+  spec.add_dependency "redis", ">= 3.0"
   spec.add_dependency "ruby-progressbar", "~> 1.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
Relax redis version to be able to bump to redis-rb 4. I've also removed a few ruby 2.5 warnings 😄 