### PR TITLE
allow to pass a class or a proc to define the prefix for the redis key

### DIFF
--- a/lib/progressrus/store/redis.rb
+++ b/lib/progressrus/store/redis.rb
@@ -59,7 +59,11 @@ class Progressrus
       private
 
       def key(scope)
-        "#{prefix}:#{scope.join(":")}"
+        if prefix.respond_to?(:call)
+          prefix.call(scope)
+        else
+          "#{prefix}:#{scope.join(":")}"
+        end
       end
 
       def deserialize(value)


### PR DESCRIPTION
We need to dynamically set the prefix base on the `pod_id` for the migration of keys of the Multi-Redis project.

https://github.com/Shopify/job-patterns/issues/202