### PR TITLE
Fix deprecated uses of `Redis#pipelined`

### DIFF
--- a/lib/progressrus/store/redis.rb
+++ b/lib/progressrus/store/redis.rb
@@ -17,9 +17,9 @@ class Progressrus
         if outdated?(progress) || force
           key_for_scope = key(progress.scope)
 
-          redis.pipelined do
-            redis.hset(key_for_scope, progress.id, progress.to_serializeable.to_json)
-            redis.expireat(key_for_scope, expires_at.to_i) if expires_at
+          redis.pipelined do |pipeline|
+            pipeline.hset(key_for_scope, progress.id, progress.to_serializeable.to_json)
+            pipeline.expireat(key_for_scope, expires_at.to_i) if expires_at
           end
 
           @persisted_ats[progress.scope][progress.id] = now


### PR DESCRIPTION
Context: https://github.com/redis/redis-rb/pull/1059

The following is deprecated
```ruby
redis.pipelined do
  redis.get(key)
end
```

And should be rewritten as:
```ruby
redis.pipelined do |pipeline|
  pipeline.get(key)
end
```

Functionally it makes no difference.