### PR TITLE
Use connection pool for Redis

### DIFF
--- a/progressrus.gemspec
+++ b/progressrus.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "redis", ">= 3.0"
+  spec.add_dependency "redis", ">= 4.7.0"
   spec.add_dependency "ruby-progressbar", "~> 1.0"
 
   spec.add_development_dependency "rake"


### PR DESCRIPTION
The Redis instance might not be the client itself, but a connection pool. This PR makes progressrus call `.with` to obtain a connection from the pool.

Thankfully, `Redis::Client` [implements](https://github.com/redis/redis-rb/blob/082d19800505c949294ce9dc6b91be9b9e539aed/lib/redis.rb#L94-L96) `with` to be backward compatible with the connection pool implementation. So we can safely ship this and it will be a no-op for those who don't use connection pooling.

cc @byroot